### PR TITLE
Fix example #1

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ or
 
 #### Example \#1
 
-    $ inq rubygems/rubygems 2016-12-01 --output report-2016-12-01.html
+    $ inq --repository rubygems/rubygems --date 2016-12-01 --output report-2016-12-01.html
 
 The above command creates a HTML file containing the report for the state of
 the rubygems/rubygems repository, for November 01 2016 to


### PR DESCRIPTION
I tried the `Example #1` in the documentation, but it seems is missing some flags.
```shell
$ inq rubygems/rubygems 2016-12-01 --output report-2016-12-01.html
inq: error: missing argument: --date
$ inq rubygems/rubygems --date 2016-12-01 --output report-2016-12-01.html
inq: error: missing argument: --repository or --config
```

This PR add those flags to the example in the `README`
