### PR TITLE
Enable Ruby 2.7 on macOS

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -39,8 +39,7 @@ macOS_task:
     matrix:
       - RUBY_VERSION: 2.5
       - RUBY_VERSION: 2.6
-      # Un-comment the following line when 2.7 is available via Homebrew.
-      #- RUBY_VERSION: 2.7
+      - RUBY_VERSION: 2.7
     PATH: "/usr/local/opt/ruby@${RUBY_VERSION}/bin:$HOME/.gem/ruby/${RUBY_VERSION}.0/bin:$PATH"
   install_script:
     - "brew install ruby@${RUBY_VERSION}"


### PR DESCRIPTION
Closes #283.

(I'm not picking inq development back up, I'm just trying to resolve as many of the smaller open issues as I can before archiving the repo.)